### PR TITLE
fix(deploy): run deploy workflow only after CI success with correct commit checkout

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,9 +1,14 @@
 name: Dependabot auto-merge
+
 on: pull_request_target
 
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge
+  cancel-in-progress: false
 
 jobs:
   dependabot:
@@ -18,7 +23,14 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          n=0
+          until [ $n -ge 3 ]; do
+            gh pr merge --auto --squash "$PR_URL" && break
+            echo "Retrying auto-merge... ($((n+1)))"
+            n=$((n+1))
+            sleep 5
+          done
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,10 @@
 name: Deploy
 
 on:
-  pull_request:
-    branches: [ main ]
-  push:
-    branches: [ main ]
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -13,7 +12,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-${{ github.ref_name }}
+  group: deploy-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
@@ -21,11 +20,17 @@ jobs:
     name: Build Web App
     runs-on: ubuntu-latest
 
-    if: github.ref_name == 'main'
+    if: >-
+      ${{ 
+        github.event.workflow_run.conclusion == 'success' && 
+        github.event.workflow_run.head_branch == 'main' 
+      }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -97,8 +102,6 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
-
-    if: github.ref_name == 'main'
 
     environment:
       name: github-pages


### PR DESCRIPTION
## Fix deploy workflow to trigger only after CI success and deploy correct built commit
Closes #160 

Improve Dependabot auto-merge reliability by adding retry and preventing concurrent runs
Closes #161 