### PR TITLE
Add reference to PAT usage Wiki in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,3 +1,6 @@
+# See also:
+# https://github.com/aim2bpg/rubree/wiki/Using-PAT-to-Trigger-Workflows-After-Auto‐Merge-in-GitHub-Actions
+
 name: Dependabot auto-merge
 
 on: pull_request_target


### PR DESCRIPTION
## Fix: GitHub Pages Deployment Skipped After Dependabot Auto-Merge
Closes #140 