### PR TITLE
Fix font loading by bypassing Google Fonts in Service Worker

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,8 @@
     <link rel="apple-touch-icon" href="/icon.png">
 
     <!-- Google Fonts: Example using Inter -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,650;1,650&display=swap" rel="stylesheet">
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>

--- a/pwa/rails.sw.js
+++ b/pwa/rails.sw.js
@@ -77,16 +77,23 @@ self.addEventListener("install", (event) => {
 const rackHandler = new RackHandler(initVM, { assumeSSL: true });
 
 self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+
+  if (url.origin !== location.origin) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   const bootResources = ["./boot", "./boot.js", "./boot.html", "./rails.sw.js"];
 
   if (
-    bootResources.find((r) => new URL(event.request.url).pathname.endsWith(r))
+    bootResources.find((r) => url.pathname.endsWith(r))
   ) {
     console.log(
       "[rails-web] Fetching boot files from network:",
       event.request.url,
     );
-    event.respondWith(fetch(event.request.url));
+    event.respondWith(fetch(event.request));
     return;
   }
 
@@ -97,7 +104,7 @@ self.addEventListener("fetch", (event) => {
       "[rails-web] Fetching Vite files from network:",
       event.request.url,
     );
-    event.respondWith(fetch(event.request.url));
+    event.respondWith(fetch(event.request));
     return;
   }
 


### PR DESCRIPTION
### Apply "Work Sans" font to main heading for consistent cross-platform typography
Closes #167 

<img width="421" height="106" alt="image" src="https://github.com/user-attachments/assets/f4112416-4c2d-4ba6-a744-80744248ccfc" />
