### PR TITLE
Improve favicon support and performance, remove YAGNI security configs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,13 +56,5 @@ module Rubree
 
     # Don't generate system test files.
     config.generators.system_tests = nil
-
-    # Security headers
-    config.action_dispatch.default_headers = {
-      "X-Frame-Options" => "SAMEORIGIN",
-      "X-Content-Type-Options" => "nosniff",
-      "X-XSS-Protection" => "0",
-      "Referrer-Policy" => "strict-origin-when-cross-origin"
-    }
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,7 +39,4 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
-
-  # Disable CSP in test environment to avoid issues with system tests
-  config.content_security_policy_report_only = true
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,22 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-Rails.application.configure do
-  config.content_security_policy do |policy|
-    policy.default_src :self, :https
-    policy.font_src    :self, :https, :data, "fonts.googleapis.com", "fonts.gstatic.com"
-    policy.img_src     :self, :https, :data, "raw.githubusercontent.com"
-    policy.object_src  :none
-    policy.script_src  :self, :https, :unsafe_eval, :unsafe_inline
-    policy.style_src   :self, :https, :unsafe_inline, "fonts.googleapis.com"
-    policy.connect_src :self, :https
-    policy.frame_ancestors :self
-  end
-
-  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
-  config.content_security_policy_nonce_directives = %w[script-src]
-
-  # Report violations without enforcing the policy.
-  # config.content_security_policy_report_only = true
-end
+# Rails.application.configure do
+#   config.content_security_policy do |policy|
+#     policy.default_src :self, :https
+#     policy.font_src    :self, :https, :data
+#     policy.img_src     :self, :https, :data
+#     policy.object_src  :none
+#     policy.script_src  :self, :https
+#     policy.style_src   :self, :https
+#     # Specify URI for violation reports
+#     # policy.report_uri "/csp-violation-report-endpoint"
+#   end
+#
+#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+#   config.content_security_policy_nonce_directives = %w(script-src style-src)
+#
+#   # Report violations without enforcing the policy.
+#   # config.content_security_policy_report_only = true
+# end

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -8,11 +8,6 @@
     <meta name="apple-mobile-web-app-title" content="Rubree">
     <meta name="mobile-web-app-capable" content="yes">
 
-    <!-- Security Headers -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; img-src 'self' https://raw.githubusercontent.com data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
-    <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-
     <!-- SEO Meta Tags -->
     <meta name="description" content="Rubree is a Ruby regular expression editor. Quickly test and visualize your regex patterns in an intuitive interface.">
     <meta name="keywords" content="Ruby, regular expression, regex tester, regex editor, online regex tool, Rubular alternative, Rubree, Ruby regex playground, pattern matching, regex visualization, live regex testing, railroad diagrams, railroad diagrams visualization, regex diagram, visual regex, regex railroads">


### PR DESCRIPTION
Favicon improvements:
- Comprehensive favicon support (all sizes: 16x16, 32x32, 96x96, ICO, SVG)
- Add apple-mobile-web-app-title for iOS
- Copy favicon.ico to root for legacy browsers
- Ensure manifest.json is deployed

Performance improvements:
- Preconnect for Google Fonts
- Non-blocking font loading
- Image dimensions (720x516) to prevent layout shift
- fetchpriority=high for LCP image
- Optimized OGP image (icon.png ~50KB)

Removed YAGNI:
- Security meta tags (ineffective on static hosting)
- Rails CSP/security headers (not needed yet)