### PR TITLE
Fix favicon.ico path and improve validator compatibility

### DIFF
--- a/pwa/index.html
+++ b/pwa/index.html
@@ -36,13 +36,13 @@
     <meta name="google-site-verification" content="8tB7v6ZsIQDKfQsVBF7k1eqxYjIt4wOFtXzRmViA65g">
 
     <!-- Favicons -->
-    <link rel="icon" href="/rubree/favicon.ico">
-    <link rel="icon" type="image/x-icon" href="/rubree/icons/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="/rubree/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/rubree/icons/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/rubree/icons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="/rubree/icons/favicon-96x96.png">
     <link rel="icon" type="image/svg+xml" href="/rubree/icon.svg">
     <link rel="apple-touch-icon" sizes="180x180" href="/rubree/icons/apple-touch-icon.png">
+    <link rel="shortcut icon" href="/rubree/favicon.ico">
     
     <!-- PWA Manifest -->
     <link rel="manifest" href="/rubree/manifest.json">


### PR DESCRIPTION
- Remove incorrect path: /rubree/icons/favicon.ico (file doesn't exist there)
- Add explicit type="image/x-icon" to main favicon declaration
- Add rel="shortcut icon" for legacy validator/browser support

This fixes favicon checker errors while maintaining all existing declarations for 96x96 PNG, manifest.json, and apple-touch-icon.