### PR TITLE
Remove duplicate ICO favicon and fix robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Disallow:
+Allow: /
 
 Sitemap: https://aim2bpg.github.io/rubree/sitemap.xml
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -42,7 +42,6 @@
     <link rel="icon" type="image/png" sizes="96x96" href="/rubree/icons/favicon-96x96.png">
     <link rel="icon" type="image/svg+xml" href="/rubree/icon.svg">
     <link rel="apple-touch-icon" sizes="180x180" href="/rubree/icons/apple-touch-icon.png">
-    <link rel="shortcut icon" href="/rubree/favicon.ico">
     
     <!-- PWA Manifest -->
     <link rel="manifest" href="/rubree/manifest.json">


### PR DESCRIPTION
- Remove rel="shortcut icon" (duplicate of main ICO favicon)
- Change robots.txt: Disallow: -> Allow: / for better validator compatibility