### PR TITLE
Add Ruby Weekly to Articles & Announcements section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,6 @@ This project is licensed under the MIT License, see the LICENSE file for details
 
 - **DEV.to — Rubree: A Modern Ruby Regex Editor Running Fully in Your Browser (2025-11-24)**
   - https://dev.to/aim2bpg/rubree-a-modern-ruby-regex-editor-running-fully-in-your-browser-5g2b
+
+- **Ruby Weekly #​777 (2025-11-27)**
+  - https://rubyweekly.com/issues/777#:~:text=Rubree


### PR DESCRIPTION
This PR adds [Rubree on Ruby Weekly #777](https://rubyweekly.com/issues/777#:~:text=Rubree) with text highlight like below when clicked.

[<img width="646" height="606" alt="image" src="https://github.com/user-attachments/assets/554e2c19-16fd-4e06-becf-ba84d0d92511" />](https://rubyweekly.com/issues/777#:~:text=Rubree)


