### PR TITLE
Fix image paths to use relative URLs

### DIFF
--- a/pwa/.gitignore
+++ b/pwa/.gitignore
@@ -20,9 +20,6 @@
 .DS_Store
 *.pem
 
-# copied images (synced from ../public/images via prepare_static_files.sh)
-/public/images
-
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -82,10 +82,10 @@
           <div class="hero-preview">
             <div class="preview-frame">
               <picture>
-                <source media="(max-width: 767px)" srcset="/images/site_view_mobile.webp" type="image/webp">
-                <source media="(max-width: 767px)" srcset="/images/site_view_mobile.png" type="image/png">
-                <source srcset="/images/site_view.webp" type="image/webp">
-                <img id="site-image" src="/images/site_view.png" alt="Site View" width="720" height="516" fetchpriority="high" decoding="async">
+                <source media="(max-width: 767px)" srcset="images/site_view_mobile.webp" type="image/webp">
+                <source media="(max-width: 767px)" srcset="images/site_view_mobile.png" type="image/png">
+                <source srcset="images/site_view.webp" type="image/webp">
+                <img id="site-image" src="images/site_view.png" alt="Site View" width="720" height="516" fetchpriority="high" decoding="async">
               </picture>
             </div>
           </div>


### PR DESCRIPTION
Use relative paths (images/...) instead of absolute paths (/images/...) so that Vite's base configuration correctly resolves them in both development (/) and production (/rubree/) environments.