### PR TITLE
chore: improve CI cache design and make Claude Code install opt-in

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,6 @@
     "source=${localEnv:HOME}/.rustup,target=/home/vscode/.rustup,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.cache/ms-playwright,target=/home/vscode/.cache/ms-playwright,type=bind,consistency=cached"
   ],
-  "postCreateCommand": "bash .devcontainer/setup.sh"
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "postStartCommand": "~/.rbenv/bin/rbenv rehash"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,9 @@
     "source=${localEnv:HOME}/.rustup,target=/home/vscode/.rustup,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.cache/ms-playwright,target=/home/vscode/.cache/ms-playwright,type=bind,consistency=cached"
   ],
+  "remoteEnv": {
+    "REMOTE_CONTAINERS": "true"
+  },
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "postStartCommand": "~/.rbenv/bin/rbenv rehash"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
     "source=${localEnv:HOME}/.cache/ms-playwright,target=/home/vscode/.cache/ms-playwright,type=bind,consistency=cached"
   ],
   "remoteEnv": {
-    "REMOTE_CONTAINERS": "true"
+    "REMOTE_CONTAINERS": "true",
+    "RUBREE_INSTALL_CLAUDE_CODE": "${localEnv:RUBREE_INSTALL_CLAUDE_CODE}"
   },
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "postStartCommand": "~/.rbenv/bin/rbenv rehash"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -29,6 +29,7 @@ if ! rbenv versions --bare | grep -qx "$RUBY_VERSION"; then
   rbenv install "$RUBY_VERSION"
 fi
 rbenv global "$RUBY_VERSION"
+rbenv rehash
 
 # --- nvm + Node.js ---
 if [ ! -s "$HOME/.nvm/nvm.sh" ]; then
@@ -44,6 +45,15 @@ if [ ! -d "$NVM_DIR/versions/node/v$NODE_VERSION" ]; then
 fi
 nvm use "$NODE_VERSION"
 nvm alias default "$NODE_VERSION"
+
+# Create system-wide symlinks so non-interactive shells (lefthook hooks) can find node/yarn
+sudo ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/node" /usr/local/bin/node
+sudo ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/npm" /usr/local/bin/npm
+sudo ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/npx" /usr/local/bin/npx
+if ! "$NVM_DIR/versions/node/v$NODE_VERSION/bin/npm" list -g yarn --depth=0 &>/dev/null; then
+  "$NVM_DIR/versions/node/v$NODE_VERSION/bin/npm" install -g yarn
+fi
+sudo ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/yarn" /usr/local/bin/yarn
 
 # --- Playwright browsers (MCP + system tests) ---
 # chromium: used by Playwright MCP server

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -81,6 +81,13 @@ if ! command -v wasi-vfs &>/dev/null; then
   rm -rf /tmp/wasi-vfs.zip /tmp/wasi-vfs
 fi
 
+# --- Google Chrome (for Selenium/Chrome system tests) ---
+if ! command -v google-chrome &>/dev/null; then
+  curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o /tmp/google-chrome.deb
+  sudo apt-get install -y /tmp/google-chrome.deb
+  rm /tmp/google-chrome.deb
+fi
+
 # --- gitleaks (secret scanner used in pre-commit hook) ---
 GITLEAKS_VERSION="8.26.0"
 if ! command -v gitleaks &>/dev/null; then

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -58,10 +58,11 @@ sudo ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/yarn" /usr/local/bin/yarn
 # --- Playwright browsers (MCP + system tests) ---
 # chromium: used by Playwright MCP server
 # chromium-headless-shell: used by capybara-playwright-driver in RSpec system tests
+# firefox, webkit: used by pre-push system tests (lefthook)
 if ! npx -y playwright --version &>/dev/null; then
-  npx -y playwright install chromium chromium-headless-shell --with-deps
+  npx -y playwright install chromium chromium-headless-shell firefox webkit --with-deps
 else
-  npx playwright install chromium chromium-headless-shell --with-deps
+  npx playwright install chromium chromium-headless-shell firefox webkit --with-deps
 fi
 
 # --- Rust + wasi-vfs ---

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -107,8 +107,9 @@ add_if_missing 'export NVM_DIR="$HOME/.nvm"'
 add_if_missing '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
 add_if_missing '. "$HOME/.cargo/env"'
 
-# --- Claude Code ---
-if ! command -v claude &>/dev/null; then
+# --- Claude Code (optional) ---
+# Set RUBREE_INSTALL_CLAUDE_CODE=1 in your shell profile to install Claude Code (https://claude.ai/code).
+if [ "${RUBREE_INSTALL_CLAUDE_CODE:-0}" = "1" ] && ! command -v claude &>/dev/null; then
   sudo mkdir -p "$HOME/.cache/claude"
   sudo chown -R "$USER:$USER" "$HOME/.cache"
   curl -fsSL https://claude.ai/install.sh | bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ./.node-version
-          cache: yarn
-          cache-dependency-path: ./yarn.lock
+      - name: Extract Biome version
+        id: biome-version
+        run: echo "version=$(jq -r '.devDependencies["@biomejs/biome"]' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: latest
-        
+          version: ${{ steps.biome-version.outputs.version }}
+
       - name: Run Biome
         run: biome ci app/assets/stylesheets app/javascript app/views
 
@@ -59,12 +56,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Extract Gitleaks version
+        id: gitleaks-version
+        run: echo "version=$(grep -oP 'GITLEAKS_VERSION=\"\K[^\"]+' .devcontainer/setup.sh)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Gitleaks binary
+        id: gitleaks-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.local/bin/gitleaks
+          key: gitleaks-${{ runner.os }}-${{ steps.gitleaks-version.outputs.version }}
+
+      - name: Install Gitleaks
+        if: steps.gitleaks-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/bin
+          VERSION="${{ steps.gitleaks-version.outputs.version }}"
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C ~/.local/bin gitleaks
+
       - name: Run Gitleaks
         run: |
-          docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" \
-          zricethezav/gitleaks detect --source="$(pwd)" --verbose --redact \
-          --log-opts="--all --full-history"
-          
+          export PATH="$HOME/.local/bin:$PATH"
+          gitleaks detect --source="$(pwd)" --verbose --redact --log-opts="--all --full-history"
+
   sast:
     name: SAST
     runs-on: ubuntu-latest
@@ -120,7 +135,15 @@ jobs:
           npx playwright install chromium
           npx playwright install-deps chromium
 
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
+
       - name: Install JS dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
       - name: Build frontend assets

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,14 @@ jobs:
           cache: yarn
           cache-dependency-path: ./pwa/yarn.lock
 
-      - name: Install Yarn
-        run: npm install -g yarn
+      - name: Extract Yarn version
+        id: yarn-version
+        run: echo "version=$(jq -r '.packageManager' pwa/package.json | cut -d'@' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Enable Yarn via Corepack
+        run: |
+          corepack enable
+          corepack prepare "yarn@${{ steps.yarn-version.outputs.version }}" --activate
 
       - name: Cache Ruby Wasm Artefacts
         id: cache-ruby-wasm
@@ -88,10 +94,19 @@ jobs:
       - name: Pack app.wasm
         run: bin/rails wasmify:pack
 
+      - name: Cache node_modules (PWA)
+        id: pwa-node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: pwa/node_modules
+          key: ${{ runner.os }}-pwa-node_modules-${{ hashFiles('pwa/yarn.lock') }}
+
       - name: Build PWA
         working-directory: pwa
         run: |
-          yarn install
+          if [ "${{ steps.pwa-node-modules-cache.outputs.cache-hit }}" != "true" ]; then
+            yarn install
+          fi
           yarn build
 
       - name: Prepare static files (sitemap, robots, icons)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ cd rubree
 
 2. Open the folder in [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and select **Reopen in Container**. Ruby, Node.js, and Rust are set up automatically.
 
-3. (Optional) Install [Claude Code](https://claude.ai/code) for AI-assisted development:
+3. (Optional) [Claude Code](https://claude.ai/code) is not installed by default. To have it installed automatically when the container is created, set `RUBREE_INSTALL_CLAUDE_CODE=1` in your host shell profile before reopening in the container:
+
+```
+export RUBREE_INSTALL_CLAUDE_CODE=1
+```
+
+Otherwise, install it manually inside the container:
 
 ```
 curl -fsSL https://claude.ai/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ cd rubree
 
 2. Open the folder in [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and select **Reopen in Container**. Ruby, Node.js, and Rust are set up automatically.
 
-3. (Optional) [Claude Code](https://claude.ai/code) is not installed by default. To have it installed automatically when the container is created, set `RUBREE_INSTALL_CLAUDE_CODE=1` in your host shell profile before reopening in the container:
+3. (Optional) [Claude Code](https://claude.ai/code) is not installed by default. To have it installed automatically when the container is created, add to your host shell profile before reopening in the container:
 
-```
-export RUBREE_INSTALL_CLAUDE_CODE=1
+```sh
+echo 'export RUBREE_INSTALL_CLAUDE_CODE=1' >> ~/.bashrc   # bash
+echo 'export RUBREE_INSTALL_CLAUDE_CODE=1' >> ~/.zshrc    # zsh
 ```
 
 Otherwise, install it manually inside the container:

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -25,14 +25,17 @@ RSpec.configure do |config|
   end
 end
 
-# Chrome requires --no-sandbox and --disable-dev-shm-usage in Docker/devcontainer environments
-Capybara.register_driver(:selenium_chrome_headless) do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless=new")
-  options.add_argument("--no-sandbox")
-  options.add_argument("--disable-dev-shm-usage")
-  options.add_argument("--disable-gpu")
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+# In devcontainer (Docker), Chrome needs --no-sandbox and --disable-dev-shm-usage.
+# Outside devcontainer, use Rails' default driver without extra flags.
+if ENV["REMOTE_CONTAINERS"] == "true"
+  Capybara.register_driver(:selenium_chrome_headless) do |app|
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  end
 end
 
 Capybara.register_driver(:playwright) do |app|

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -25,6 +25,16 @@ RSpec.configure do |config|
   end
 end
 
+# Chrome requires --no-sandbox and --disable-dev-shm-usage in Docker/devcontainer environments
+Capybara.register_driver(:selenium_chrome_headless) do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless=new")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+  options.add_argument("--disable-gpu")
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
 Capybara.register_driver(:playwright) do |app|
   Capybara::Playwright::Driver.new(app, browser_type: :chromium, headless: true)
 end


### PR DESCRIPTION
## Summary
- `lint_frontend`: drop the unused Node.js setup (Biome runs as a standalone binary and does not need Node/yarn) and derive the Biome version from `package.json` instead of `latest`, keeping CI in sync with local linting without manual upkeep
- `test` job / PWA build: cache `node_modules` keyed on the relevant `yarn.lock` hash and skip `yarn install` entirely on cache hits
- `secret_scan`: replace the Docker-based Gitleaks invocation (fresh image pull every run) with a cached pinned binary, reusing the existing `GITLEAKS_VERSION` from `.devcontainer/setup.sh` as the single source of truth
- `deploy.yml`: replace `npm install -g yarn` with `corepack`, reading the pinned version from `pwa/package.json`packageManager field
- devcontainer: make Claude Code installation opt-in via `RUBREE_INSTALL_CLAUDE_CODE=1` (passed through remoteEnv) instead of always installing it, and document the new env var in the README

## Test plan
- [x] rubocop / erb_lint / biome / gitleaks / brakeman / rspec all pass locally via lefthook pre-commit
- [x] System tests (Playwright Firefox/WebKit, Selenium Chrome) pass via lefthook pre-push
- [x] Validated YAML/JSON syntax of all edited workflow and devcontainer files
- [ ] Confirm in CI that the new cache steps behave as expected (cache hits/misses, skip conditions) and observe the run-time improvement
