### PR TITLE
fix: use a marker file for Claude Code opt-in rbenv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,20 +2,20 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu24.04",
   "remoteUser": "vscode",
   "containerUser": "vscode",
-  "initializeCommand": "mkdir -p ${localEnv:HOME}/.claude ${localEnv:HOME}/.ssh ${localEnv:HOME}/.rbenv ${localEnv:HOME}/.nvm ${localEnv:HOME}/.cargo ${localEnv:HOME}/.rustup ${localEnv:HOME}/.cache/ms-playwright",
+  "initializeCommand": "mkdir -p ${localEnv:HOME}/.claude ${localEnv:HOME}/.ssh ${localEnv:HOME}/.nvm ${localEnv:HOME}/.cargo ${localEnv:HOME}/.rustup ${localEnv:HOME}/.cache/ms-playwright",
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached,readonly",
-    "source=${localEnv:HOME}/.rbenv,target=/home/vscode/.rbenv,type=bind,consistency=cached",
+    "source=rubree-rbenv,target=/home/vscode/.rbenv,type=volume",
     "source=${localEnv:HOME}/.nvm,target=/home/vscode/.nvm,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.cargo,target=/home/vscode/.cargo,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.rustup,target=/home/vscode/.rustup,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.cache/ms-playwright,target=/home/vscode/.cache/ms-playwright,type=bind,consistency=cached"
   ],
   "remoteEnv": {
-    "REMOTE_CONTAINERS": "true",
-    "RUBREE_INSTALL_CLAUDE_CODE": "${localEnv:RUBREE_INSTALL_CLAUDE_CODE}"
+    "REMOTE_CONTAINERS": "true"
   },
+  "onCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.rbenv",
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "postStartCommand": "~/.rbenv/bin/rbenv rehash"
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -108,8 +108,10 @@ add_if_missing '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
 add_if_missing '. "$HOME/.cargo/env"'
 
 # --- Claude Code (optional) ---
-# Set RUBREE_INSTALL_CLAUDE_CODE=1 in your shell profile to install Claude Code (https://claude.ai/code).
-if [ "${RUBREE_INSTALL_CLAUDE_CODE:-0}" = "1" ] && ! command -v claude &>/dev/null; then
+# To install Claude Code (https://claude.ai/code), create a marker file at the
+# workspace root (gitignored, so it's local-only and scoped to this clone):
+#   touch .install-claude-code
+if [ -f "$WORKSPACE_ROOT/.install-claude-code" ] && ! command -v claude &>/dev/null; then
   sudo mkdir -p "$HOME/.cache/claude"
   sudo chown -R "$USER:$USER" "$HOME/.cache"
   curl -fsSL https://claude.ai/install.sh | bash

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore all environment files.
 /.env*
 
+# Marker file to opt in to installing Claude Code in the Dev Container.
+/.install-claude-code
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ cd rubree
 
 2. Open the folder in [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and select **Reopen in Container**. Ruby, Node.js, and Rust are set up automatically.
 
-3. (Optional) [Claude Code](https://claude.ai/code) is not installed by default. To have it installed automatically when the container is created, add to your host shell profile before reopening in the container:
+3. (Optional) [Claude Code](https://claude.ai/code) is not installed by default. To have it installed automatically when the container is created, create a marker file at the workspace root before (re)building the container:
 
 ```sh
-echo 'export RUBREE_INSTALL_CLAUDE_CODE=1' >> ~/.bashrc   # bash
-echo 'export RUBREE_INSTALL_CLAUDE_CODE=1' >> ~/.zshrc    # zsh
+touch .install-claude-code
 ```
+
+The file is gitignored and scoped to this clone, so it won't affect other projects or checkouts.
 
 Otherwise, install it manually inside the container:
 


### PR DESCRIPTION
The RUBREE_INSTALL_CLAUDE_CODE env var had to be threaded through remoteEnv and didn't survive container rebuilds reliably. A gitignored marker file at the workspace root (.install-claude-code) is simpler, persists across rebuilds, and is naturally scoped to the clone.

Bind-mounting a host ~/.rbenv also bakes the host username into rbenv's shims (RBENV_ROOT pointing at /home/<host-user>/.rbenv), breaking them when the host and container usernames differ. Switching to a named Docker volume avoids this mismatch entirely.