### PR TITLE
chore: cache root node_modules and doc path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
 
 concurrency:
   group: ci-${{ github.ref_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,12 @@ jobs:
         if: steps.cache-ruby-wasm-module.outputs.cache-hit != 'true'
         run: bin/rails wasmify:build
 
+      - name: Cache node_modules (root)
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-root-node_modules-${{ hashFiles('yarn.lock') }}
+
       - name: Pack app.wasm
         run: bin/rails wasmify:pack
 


### PR DESCRIPTION
Pack app.wasm runs `assets:precompile`, which jsbundling-rails/cssbundling-rails enhance with a `yarn install` for the root node_modules — previously uncached, this caused the step to vary ~10x (45s vs 7-9min) depending on npm registry conditions. Cache it the same way the PWA node_modules already are.

Also skip CI (and the workflow_run-triggered Deploy) for changes that only touch Markdown files, since they don't affect the build or test outcome.