### PR TITLE
fix: key Ruby Wasm artefact cache on Gemfile.lock

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,7 @@ jobs:
           path: |
             build
             rubies
-          key: ${{ runner.os }}-v1-${{ hashFiles('.ruby-version') }}-ruby-wasm
+          key: ${{ runner.os }}-v1-${{ hashFiles('.ruby-version', '**/Gemfile.lock') }}-ruby-wasm
 
       - name: Cache Compiled ruby.wasm Module
         id: cache-ruby-wasm-module
@@ -90,12 +90,6 @@ jobs:
       - name: Build ruby.wasm (if needed)
         if: steps.cache-ruby-wasm-module.outputs.cache-hit != 'true'
         run: bin/rails wasmify:build
-
-      - name: Cache node_modules (root)
-        uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-root-node_modules-${{ hashFiles('yarn.lock') }}
 
       - name: Pack app.wasm
         run: bin/rails wasmify:pack


### PR DESCRIPTION
## Summary
- The `rubies/*.tar.gz` artefact filename embeds an MD5 hash of native-extension gem versions (e.g. `websocket-driver-0.8.x`), but the "Cache Ruby Wasm Artefacts" cache key only tracked `.ruby-version`. A gem bump (`websocket-driver` 0.8.0 -> 0.8.1, #630) silently produced a mismatched artefact name -- `wasmify:build` could not find a matching tarball, fell back to a full ~8min `./configure && make` rebuild inside "Pack app.wasm", and since the cache key had not changed, `actions/cache` refused to save the freshly built tarball ("Cache hit occurred on the primary key ..., not saving cache"). This left every subsequent deploy stuck on the same full rebuild until `.ruby-version` changes again. Hashing `Gemfile.lock` into the key (matching the existing "Cache Compiled ruby.wasm Module" key) gives gem bumps a fresh cache slot that can actually be populated and reused.
- Also drops the "Cache node_modules (root)" step added in #634 -- its premise (yarn install variance causing 45s-vs-9min swings in "Pack app.wasm") is disproven by the above finding (the real cause is the artefact rebuild, not yarn install). As implemented, that step also provided no actual benefit since nothing skips `yarn install` on a cache hit -- the cached directory just gets reinstalled every run.

## Test plan
- [ ] Merge to `main` and confirm the next Deploy run (with the current `Gemfile.lock`/`websocket-driver-0.8.1`) does a one-time full rebuild in "Pack app.wasm" and successfully saves the new `rubies/*.tar.gz` to cache (check the post-job log for `Cache saved with key: ...-ruby-wasm`, not "not saving cache")
- [ ] Confirm the following Deploy run restores that cache and "Pack app.wasm" completes quickly (~1min) via tarball extraction rather than a full `./configure && make` rebuild
