### PR TITLE
docs: explain why ruby-wasm cache key must hash Gemfile.lock

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,11 @@ jobs:
           path: |
             build
             rubies
+          # Must include Gemfile.lock: the cached rubies/*.tar.gz filename embeds an MD5
+          # hash of native-extension gem versions (e.g. websocket-driver). If that hash
+          # changes without the cache key changing, the restored tarball no longer matches
+          # what wasmify:build expects, forcing a slow rebuild AND a permanent "cache hit,
+          # not saving" loop that never refreshes the stale entry.
           key: ${{ runner.os }}-v1-${{ hashFiles('.ruby-version', '**/Gemfile.lock') }}-ruby-wasm
 
       - name: Cache Compiled ruby.wasm Module


### PR DESCRIPTION
Records the root cause found while investigating the wildly varying "Pack app.wasm" duration: the cached rubies/*.tar.gz artifact's filename embeds an MD5 of native-extension gem versions, so a gem bump (e.g. websocket-driver 0.8.0 -> 0.8.1) without a matching cache key change leaves a stale, unsalvageable cache entry that forces a slow rebuild every run and is never refreshed.