### PR TITLE
fix: scope WASM cache keys to the :wasm bundle group

### DIFF
--- a/.claude/skills/ci-cd-pipeline/SKILL.md
+++ b/.claude/skills/ci-cd-pipeline/SKILL.md
@@ -32,11 +32,23 @@ environments stay in sync.
 Triggered after CI succeeds on `main`. Builds `ruby.wasm` (`wasmify:build` / `wasmify:pack`),
 builds the PWA frontend, and publishes the static site to GitHub Pages.
 
-The WASM build is cached, keyed on a hash of **both** `.ruby-version` **and** `Gemfile.lock` —
-see the inline comment in `deploy.yml` for why both are required (also explained in
-`docs/wasm-build-notes.md`): the cached `rubies/*.tar.gz` filename embeds an MD5 hash of
-native-extension gem versions, so a `Gemfile.lock` change can invalidate the cache even when
-`.ruby-version` doesn't change.
+The WASM build uses **two-tier cache keys** scoped to the `:wasm` bundle group, computed by
+`script/wasm_build_fingerprint.rb` (run with `BUNDLE_ONLY=wasm`, same Bundler definition as
+`wasmify:build`) — see the inline comment in `deploy.yml` for the full rationale:
+
+- **`exts` fingerprint** (rubies/build artefact cache): native-extension gems only. The cached
+  `rubies/*.tar.gz` filename embeds an MD5 of exactly these gem versions, so this key rotates
+  if and only if a cross-compile is needed.
+- **`all` fingerprint** (compiled ruby.wasm module cache): every `:wasm`-group gem, because the
+  whole bundle is embedded into ruby.wasm (`require "/bundle/setup"`). A pure-Ruby gem bump
+  rotates only this key — the module is rebuilt but the compiled tarball is reused.
+- Both keys also hash `.ruby-version`, `config/wasmify.yml`, `ruby_wasm_patches/**`, and
+  `lib/tasks/wasmify_patches.rake`, since those change build output too.
+
+Hashing the whole `Gemfile.lock` instead would invalidate both caches on every Dependabot bump —
+including dev/test gems that never reach the WASM build — costing 12+ min per deploy. Hashing
+too little is worse: a stale `exts` key causes a tarball-name mismatch, forcing a slow rebuild
+**and** a permanent "cache hit, not saving" loop (the PR #635/#636 bug).
 
 **Takeaway**: when bumping a tool version (Ruby, Node, Rust, wasi-vfs), update the relevant
 dotfile — setup.sh, ci.yml, and deploy.yml all key off it, so one edit propagates everywhere.
@@ -56,12 +68,17 @@ $ echo "4.0.6" > .ruby-version   # one edit propagates everywhere
 ```
 
 ```yaml
-# ✅ WASM cache key hashes both .ruby-version AND Gemfile.lock (deploy.yml)
-key: ruby-wasm-${{ hashFiles('.ruby-version', 'Gemfile.lock') }}
+# ✅ WASM cache keys use the wasm-group fingerprints + build-input files (deploy.yml)
+key: ...-${{ hashFiles('.ruby-version', 'config/wasmify.yml', 'ruby_wasm_patches/**', 'lib/tasks/wasmify_patches.rake') }}-${{ steps.wasm-fingerprint.outputs.exts }}-ruby-wasm
 
-# ❌ hash only .ruby-version — a Gemfile.lock change (new native-extension gem) won't
-#    bust the cache, and the stale rubies/*.tar.gz will be used silently
-key: ruby-wasm-${{ hashFiles('.ruby-version') }}
+# ❌ hash the whole Gemfile.lock — every Dependabot bump (rubocop, rspec, sqlite3…)
+#    busts both caches and triggers a 12+ min cross-compile that changes nothing
+key: ...-${{ hashFiles('.ruby-version', '**/Gemfile.lock') }}-ruby-wasm
+
+# ❌ hash only .ruby-version — a native-extension gem bump won't bust the cache;
+#    the rubies/*.tar.gz filename mismatch then forces a slow rebuild on every
+#    deploy AND a permanent "cache hit, not saving" loop (PR #635/#636)
+key: ...-${{ hashFiles('.ruby-version') }}-ruby-wasm
 ```
 
 ```yaml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,27 @@ jobs:
           corepack enable
           corepack prepare "yarn@${{ steps.yarn-version.outputs.version }}" --activate
 
+      # Two-tier cache keys, scoped to what actually feeds the WASM build. Hashing the
+      # whole Gemfile.lock here would invalidate both caches on every Dependabot bump,
+      # even for gems outside the :wasm group that never reach the build (12+ min of
+      # wasted cross-compilation). The fingerprints come from the same Bundler
+      # definition wasmify:build uses (BUNDLE_ONLY=wasm), so they rotate exactly when
+      # the build inputs change:
+      #
+      #   exts — native-extension gems compiled into rubies/*.tar.gz. The tarball
+      #          filename embeds an MD5 of these full_names, so a stale "exts" key
+      #          would cause the name-mismatch rebuild + "cache hit, not saving" loop
+      #          documented in PR #635/#636.
+      #   all  — every :wasm-group gem (embedded into ruby.wasm as /bundle). A pure-Ruby
+      #          gem bump rotates only this key: the module is rebuilt, but the compiled
+      #          tarball is reused, skipping the slow cross-compile.
+      #
+      # The module key's inputs are a superset of the artefact key's, so "module hit
+      # but artefacts stale" cannot happen.
+      - name: Compute WASM build fingerprints
+        id: wasm-fingerprint
+        run: BUNDLE_ONLY=wasm bundle exec ruby script/wasm_build_fingerprint.rb >> "$GITHUB_OUTPUT"
+
       - name: Cache Ruby Wasm Artefacts
         id: cache-ruby-wasm
         uses: actions/cache@v5
@@ -78,19 +99,14 @@ jobs:
           path: |
             build
             rubies
-          # Must include Gemfile.lock: the cached rubies/*.tar.gz filename embeds an MD5
-          # hash of native-extension gem versions (e.g. websocket-driver). If that hash
-          # changes without the cache key changing, the restored tarball no longer matches
-          # what wasmify:build expects, forcing a slow rebuild AND a permanent "cache hit,
-          # not saving" loop that never refreshes the stale entry.
-          key: ${{ runner.os }}-v1-${{ hashFiles('.ruby-version', '**/Gemfile.lock') }}-ruby-wasm
+          key: ${{ runner.os }}-v2-${{ hashFiles('.ruby-version', 'config/wasmify.yml', 'ruby_wasm_patches/**', 'lib/tasks/wasmify_patches.rake') }}-${{ steps.wasm-fingerprint.outputs.exts }}-ruby-wasm
 
       - name: Cache Compiled ruby.wasm Module
         id: cache-ruby-wasm-module
         uses: actions/cache@v5
         with:
           path: tmp/wasmify/ruby.wasm
-          key: ${{ runner.os }}-v1-${{ hashFiles('.ruby-version', '**/Gemfile.lock') }}-ruby-wasm-module
+          key: ${{ runner.os }}-v2-${{ hashFiles('.ruby-version', 'config/wasmify.yml', 'ruby_wasm_patches/**', 'lib/tasks/wasmify_patches.rake') }}-${{ steps.wasm-fingerprint.outputs.all }}-ruby-wasm-module
 
       - name: Build ruby.wasm (if needed)
         if: steps.cache-ruby-wasm-module.outputs.cache-hit != 'true'

--- a/script/wasm_build_fingerprint.rb
+++ b/script/wasm_build_fingerprint.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Print cache fingerprints for the WASM build (consumed by .github/workflows/deploy.yml).
+#
+# Must run with BUNDLE_ONLY=wasm so the Bundler definition matches what
+# `bin/rails wasmify:build` sees (the rake task re-execs itself with BUNDLE_ONLY=wasm).
+#
+# Output is GITHUB_OUTPUT-compatible, one fingerprint per line:
+#
+#   exts=<sha256>  Native-extension gems that ruby_wasm cross-compiles into the
+#                  rubies/*.tar.gz tarball. Mirrors RubyWasm::Packager::Core::
+#                  BuildStrategy#specs_with_extensions: specs with extensions,
+#                  minus config/wasmify.yml exclude_gems / ignore_gem_extensions
+#                  (applied by Wasmify::Rails::Builder) and the packager's own
+#                  EXCLUDED_GEMS. The tarball filename embeds an MD5 of exactly
+#                  these full_names, so this fingerprint changes if and only if
+#                  a recompile is needed.
+#
+#   all=<sha256>   Every gem resolved in the :wasm group. These are embedded
+#                  into ruby.wasm as the /bundle filesystem image (the shim's
+#                  `require "/bundle/setup"`), so any version change here makes
+#                  the compiled ruby.wasm module stale even when no native
+#                  extension changed. Includes ruby_wasm and wasmify-rails
+#                  themselves, so toolchain bumps also rotate this fingerprint.
+#
+# Pass --list to also print the gem lists to stderr for debugging.
+
+abort "error: run with BUNDLE_ONLY=wasm (got: #{ENV["BUNDLE_ONLY"].inspect})" unless ENV["BUNDLE_ONLY"] == "wasm"
+
+require "bundler"
+require "digest"
+require "yaml"
+
+definition = Bundler.definition
+specs = definition.resolve.materialize(definition.requested_dependencies)
+
+# A LazySpecification means a locked gem is not actually installed. Dropping it
+# would silently shrink the fingerprint and risk reusing a stale cache entry, so
+# fail loudly instead (CI installs the full bundle before running this script).
+lazy = specs.select { |spec| spec.is_a?(Bundler::LazySpecification) }
+abort "error: unmaterialized specs (run bundle install first): #{lazy.map(&:full_name).join(", ")}" if lazy.any?
+
+wasmify_config = YAML.load_file(File.expand_path("../config/wasmify.yml", __dir__))
+excluded = (wasmify_config["exclude_gems"] || []) +
+  (wasmify_config["ignore_gem_extensions"] || []) +
+  %w[ruby_wasm bundler] # RubyWasm::Packager::EXCLUDED_GEMS
+
+ext_names = specs
+  .select { |spec| spec.extensions.any? }
+  .reject { |spec| excluded.include?(spec.name) }
+  .map(&:full_name).sort
+all_names = specs.map(&:full_name).sort
+
+if ARGV.include?("--list")
+  warn "exts:\n  #{ext_names.join("\n  ")}"
+  warn "all:\n  #{all_names.join("\n  ")}"
+end
+
+puts "exts=#{Digest::SHA256.hexdigest(ext_names.join("\n"))}"
+puts "all=#{Digest::SHA256.hexdigest(all_names.join("\n"))}"


### PR DESCRIPTION
### **Overview (What)**

Replace the deploy workflow's WASM cache keys (previously a hash of the entire `Gemfile.lock`) with two fingerprints computed from the `:wasm` bundle group by a new `script/wasm_build_fingerprint.rb`, so Dependabot bumps of gems that never reach the WASM build no longer trigger a 12+ minute Ruby cross-compile.

### **Background (Why)**

Every Dependabot merge was deploying in 13–14 min vs ~2 min for normal commits:

| Run | Commit | Deploy time | `Build ruby.wasm` step |
|---|---|---|---|
| 2026-06-10 | `net-imap 0.6.4 → 0.6.4.1` | 829s | 720s (full rebuild) |
| 2026-06-08 | `sqlite3 2.9.4 → 2.9.5` | 891s | full rebuild |
| 2026-06-07 | regular commit | 128s | skipped (cache hit) |

Both cache keys hashed `**/Gemfile.lock`, so *any* gem bump — including dev/test gems like `sqlite3`, `rubocop`, `rspec` that are not in the `:wasm` group — invalidated both caches. Reading `ruby_wasm` 2.9.4's source shows what actually feeds the build:

- the `rubies/*.tar.gz` filename embeds an MD5 of **native-extension gem** `full_name`s only (`RubyWasm::Packager::Core::BuildStrategy#name`) — currently 8 gems after `config/wasmify.yml` exclusions
- the compiled `ruby.wasm` additionally embeds the whole **`:wasm`-group bundle** as `/bundle` (the shim's `require "/bundle/setup"`)

### **Details (How)**

Two-tier keys, both computed under `BUNDLE_ONLY=wasm` (the same Bundler definition `wasmify:build` re-execs itself with):

- **`exts`** → `build`/`rubies` artefact cache: native-extension specs minus `wasmify.yml` `exclude_gems`/`ignore_gem_extensions`, mirroring the tarball-name MD5. Rotates iff a cross-compile is needed.
- **`all`** → compiled `ruby.wasm` module cache: every resolved `:wasm`-group spec. A pure-Ruby wasm-group bump (e.g. `net-imap` via `mail`) rotates only this key: the module is re-embedded but the compiled tarball is reused, skipping the slow compile.

Design notes:

- The module key's inputs are a superset of the artefact key's, so "module hit but stale artefacts" — the failure mode behind the #635/#636 "cache hit, not saving" loop — cannot occur.
- Both keys now also hash `config/wasmify.yml`, `ruby_wasm_patches/**`, and `lib/tasks/wasmify_patches.rake`, which affect build output but previously never busted the cache.
- The script aborts on unmaterialized (not-installed) specs instead of silently dropping them, so a broken bundle fails the deploy loudly rather than reusing a stale cache entry.
- Cache key version bumped `v1` → `v2` to force one clean rebuild on rollout.

Expected deploy times: non-wasm gem bumps (the majority) ~2 min (was 13–14); wasm-group pure-Ruby bumps ~5–8 min estimated (tarball reused); native-extension gem bumps unchanged (~13 min, genuinely needed).

### **Verification**

- `BUNDLE_ONLY=wasm bundle exec ruby script/wasm_build_fingerprint.rb --list` locally; `exts` lists exactly the expected 8 gems (`bigdecimal, date, erb, js, prism, racc, stringio, websocket-driver`)
- Tamper tests on `Gemfile.lock` (restored afterwards): `sqlite3` version change → both fingerprints unchanged; `psych` 5.4.0→5.3.1 (wasm group, excluded ext) → `all` changes only; pulling the real #639/#640 bumps → `all` rotated, `exts` stable; tampered-but-not-installed version → loud failure
- `bin/rubocop` clean; deploy.yml YAML parses; full pre-commit/pre-push hook suite passed (RSpec 207 examples 0 failures, system specs on Firefox/WebKit/Chrome)
- `deploy.yml` does not run on PRs — after merge, the first deploy will be an intentional full rebuild (v2 keys); subsequent deploys should be verified against the table above

### **Additional Notes**

- Follow-up of #635/#636, which correctly fixed the stale-cache loop but with an over-broad key.
- The ~5–8 min estimate for the middle tier (warm tarball, module rebuild) is unmeasured — worth confirming on the first wasm-group Dependabot bump after merge.
- `.claude/skills/ci-cd-pipeline/SKILL.md` updated to document the new key design.