### PR TITLE
fix: support non-ASCII named capture groups + pre-install Playwright MCP

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest", "--headless"]
+      "command": "node_modules/.bin/playwright-mcp",
+      "args": ["--headless"]
     }
   },
   "permissions": {

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ coverage/
 
 # Steering task plans (working documents; knowledge worth keeping flows to skills/ or docs/)
 .steering/
+
+# Playwright MCP auto-generated output (screenshots, console logs)
+.playwright-mcp/
+
+# Local investigation screenshots (not part of the shipped product)
+docs/onigmo-bugs/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/models/regular_expression.rb
+++ b/app/models/regular_expression.rb
@@ -22,21 +22,10 @@ class RegularExpression
     results = []
     test_string.to_enum(:scan, regexp).each do
       match = Regexp.last_match
-      captures_hash = {}
-
-      regexp.named_captures.each_key do |name|
-        begin
-          # Accessing MatchData with some multi-byte capture names can raise IndexError
-          val = match[name]
-        rescue IndexError, ArgumentError => e
-          # record a user-facing error specific to diagram/rendering, but don't raise
-          errors.add(:diagram, "Invalid named capture access: #{name}") unless errors.added?(:diagram, "Invalid named capture access: #{name}")
-          val = nil
-        end
-
-        captures_hash[name] = val if val
-      end
-
+      # MatchData#named_captures returns a Hash with correctly-encoded UTF-8 keys,
+      # unlike Regexp#named_captures whose keys are raw bytes and cause IndexError
+      # when used with MatchData#[].
+      captures_hash = match.named_captures.reject { |_, v| v.nil? }
       results << captures_hash unless captures_hash.empty?
     end
 

--- a/app/models/regular_expression/railroad_diagram_builder.rb
+++ b/app/models/regular_expression/railroad_diagram_builder.rb
@@ -323,13 +323,15 @@ class RegularExpression
     def sanitize_group_name(name)
       return nil if name.nil?
 
-      # Ensure a UTF-8 string and replace invalid/undef sequences.
-      safe = name.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+      # Strip invalid/undefined byte sequences (replace with empty string so we
+      # can detect that something was removed rather than masking with "?").
+      safe = name.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
+      return nil if safe.empty?
 
-      # Only allow ASCII word-style names (letters, digits, underscore),
-      # starting with a letter or underscore. This matches typical Ruby
-      # named-capture expectations and avoids MatchData lookup issues.
-      return safe if safe.match?(/\A[A-Za-z_][A-Za-z0-9_]*\z/)
+      # Mirror Ruby's named-capture identifier rules: must start with a Unicode
+      # letter or underscore, followed by Unicode letters, digits, or underscores.
+      # This covers ASCII names as well as non-ASCII names (e.g. Japanese).
+      return safe if safe.match?(/\A[\p{L}_][\p{L}\p{N}_]*\z/u)
 
       nil
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,8 +57,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,650;1,650&display=swap" rel="stylesheet">
 
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%# application.css = compiled Tailwind output (builds/); custom_styles.css = project overrides %>
+    <%= stylesheet_link_tag "application", "custom_styles", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -145,6 +145,23 @@ repo. Mirror critical denies in `~/.claude/settings.json` on the host machine:
 Use `/verify-wasm` — it automates the full sequence (WASM build → Vite start → Playwright MCP
 headless golden-path check). See `.claude/commands/verify-wasm.md` for details.
 
+**If Playwright MCP is not listed in the tools panel**, it means the MCP server failed to start.
+`@playwright/mcp` is declared as a devDependency in `package.json` and must be installed first:
+
+```bash
+yarn install   # installs @playwright/mcp into node_modules
+```
+
+After installing, restart Claude Code. The project-level config in `.claude/settings.json`
+(`enableAllProjectMcpServers: true`) will pick it up automatically on the next session start.
+If it still does not appear, add it at the user scope as a fallback:
+
+```bash
+claude mcp add -s user playwright -- npx @playwright/mcp@latest --headless
+```
+
+Then restart Claude Code once more.
+
 If Playwright MCP is not connected in the current session, fall back to the manual steps in
 [Test deployment locally (WASM build)](#test-deployment-locally-wasm-build) and verify in
 Chrome yourself, or run the headless script directly:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
+    "@playwright/mcp": "^0.0.76",
     "esbuild": "^0.28.1",
     "playwright": "1.59.1"
   },

--- a/spec/models/regular_expression/railroad_diagram_spec.rb
+++ b/spec/models/regular_expression/railroad_diagram_spec.rb
@@ -682,5 +682,65 @@ RSpec.describe RegularExpression::RailroadDiagram do
         expect(result).to be_nil
       end
     end
+
+    context 'when regex contains non-ASCII named capture groups' do
+      it 'renders SVG without error for Japanese group name' do
+        svg = described_class.new(regular_expression: '(?<あ>x)').generate
+        expect(svg).to include('<svg')
+        expect(svg).not_to be_nil
+      end
+
+      it 'renders SVG without error for Japanese group name with backreference' do
+        svg = described_class.new(regular_expression: '(?<あ>x)\k<あ>').generate
+        expect(svg).to include('<svg')
+        expect(svg).not_to be_nil
+      end
+    end
+  end
+
+  describe 'RegularExpression::RailroadDiagramBuilder.sanitize_group_name' do
+    subject(:sanitize) { RegularExpression::RailroadDiagramBuilder.send(:sanitize_group_name, name) }
+
+    context 'with ASCII word-style names' do
+      let(:name) { 'foo_Bar1' }
+
+      it { is_expected.to eq('foo_Bar1') }
+    end
+
+    context 'with non-ASCII (Japanese) names' do
+      let(:name) { 'あ' }
+
+      it { is_expected.to eq('あ') }
+    end
+
+    context 'with mixed ASCII and Japanese names' do
+      let(:name) { '名前abc' }
+
+      it { is_expected.to eq('名前abc') }
+    end
+
+    context 'with nil' do
+      let(:name) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with a name starting with a digit' do
+      let(:name) { '1foo' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with a name containing spaces' do
+      let(:name) { 'foo bar' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with an empty string' do
+      let(:name) { '' }
+
+      it { is_expected.to be_nil }
+    end
   end
 end

--- a/spec/models/regular_expression_spec.rb
+++ b/spec/models/regular_expression_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe RegularExpression do
         expect(regex.named_capture_groups).to eq([])
       end
     end
+
+    context 'when named capture group has a non-ASCII (Japanese) name' do
+      let(:regex) { described_class.new(regular_expression: '(?<あ>hello)', test_string: 'hello') }
+
+      it 'returns the captures without errors' do
+        expect(regex.named_capture_groups).to eq([{ 'あ' => 'hello' }])
+        expect(regex.errors[:diagram]).to be_empty
+      end
+    end
   end
 
   describe '#capture_groups' do

--- a/spec/system/regular_expressions_spec.rb
+++ b/spec/system/regular_expressions_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe "RegularExpressionFlow" do
       expect(page).to have_css 'mark', text: 'def', class: /bg-blue-200/
     end
 
-    it 'shows a friendly error in the results area when named capture access with multibyte name fails' do
+    it 'correctly matches and highlights captures for non-ASCII (multibyte) named capture groups' do
       visit root_path
 
       # use precise selectors for the textareas
@@ -296,8 +296,8 @@ RSpec.describe "RegularExpressionFlow" do
       page.execute_script("document.querySelector('form[data-controller=\\\"regexp-form\\\"]') && document.querySelector('form[data-controller=\\\"regexp-form\\\"]').requestSubmit()")
 
       within('turbo-frame#regexp') do
-        expect(page).to have_css('div.bg-red-100', wait: 5)
-        expect(page).to have_text(/Invalid named capture access|Invalid regular expression/)
+        expect(page).to have_no_css('div.bg-red-100', wait: 5)
+        expect(page).to have_css('mark', text: 'foo')
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,14 @@
     "@parcel/watcher-win32-ia32" "2.5.6"
     "@parcel/watcher-win32-x64" "2.5.6"
 
+"@playwright/mcp@^0.0.76":
+  version "0.0.76"
+  resolved "https://registry.yarnpkg.com/@playwright/mcp/-/mcp-0.0.76.tgz#fe366fc5b2696983981cd595c2ad26b5242b035b"
+  integrity sha512-ICcW6wAV+HoNEco19eni+JTVylCIIedruWkrRl2Rsv/qcGhBZLT/c0I1VounjIjSVSupw3pHmcr3CNCikTHTBQ==
+  dependencies:
+    playwright "1.61.0-alpha-1781023400000"
+    playwright-core "1.61.0-alpha-1781023400000"
+
 "@rails/actioncable@>=7.0":
   version "8.1.300"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.1.300.tgz#bfd50813be0225a0403bddb11e8ba9a00b1fb135"
@@ -676,12 +684,26 @@ playwright-core@1.59.1:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
   integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
 
+playwright-core@1.61.0-alpha-1781023400000:
+  version "1.61.0-alpha-1781023400000"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.0-alpha-1781023400000.tgz#2a75fc5208882876ec0f45f43ba0e5f9fd076663"
+  integrity sha512-UdtUd9qnCO0zvb8p3OvOZpelY6mA40mTb3NmWGuMtrD+hqqWuorWCPlSGwj7jw/LEB9AxvYLHTL1CJi2flvksg==
+
 playwright@1.59.1:
   version "1.59.1"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
   integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
   dependencies:
     playwright-core "1.59.1"
+  optionalDependencies:
+    fsevents "2.3.2"
+
+playwright@1.61.0-alpha-1781023400000:
+  version "1.61.0-alpha-1781023400000"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.0-alpha-1781023400000.tgz#ee57fa320a1f9f7eeb45c66499e2ce72802a5cde"
+  integrity sha512-8TRUG3IvwaAhuVm6k3C5vB7CwC5Fxq76DCCxOgPr6r1dpTedDwxlmdOBUkSZ0zxfxP14jcuPxi86/Trq4eA03w==
+  dependencies:
+    playwright-core "1.61.0-alpha-1781023400000"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
### **Overview (What)**

- Fix `RegularExpression#named_capture_groups` to handle non-ASCII (e.g. Japanese) named capture groups without raising `IndexError`
- Fix `RailroadDiagramBuilder#sanitize_group_name` to accept Unicode letters so non-ASCII group names render correctly in railroad diagrams
- Fix a CSS 404 caused by incorrect `stylesheet_link_tag` asset name references
- Pre-install `@playwright/mcp` as a devDependency and switch the MCP server config to use the local binary, eliminating on-demand `npx` downloads that caused session-start failures
- Bump brakeman 8.0.4 → 8.0.5 to satisfy the `--ensure-latest` gate in `bin/brakeman`

### **Background (Why)**

While reproducing [Onigmo bugs](https://github.com/makenowjust/naraku/blob/main/docs/ja/onigmo_bugs.md) in the Rubree PWA (ES2 test case), a pre-existing app bug was discovered:

- `Regexp#named_captures.each_key` returns ASCII-8BIT raw-byte keys (e.g. `"\xE3\x81\x82"` for `あ`). Passing these keys to `match[name]` raises `IndexError`, which was being caught and surfaced to users as "Invalid named capture access: ????" — a misleading error since Onigmo fully supports non-ASCII named captures.
- `sanitize_group_name` used `/\A[A-Za-z_][A-Za-z0-9_]*\z/` (ASCII-only), so Japanese group names were silently replaced with "unknown group" in railroad diagrams.

The Playwright MCP connection issue was traced to `.claude/settings.json` using `npx @playwright/mcp@latest`, which requires a fresh npm download on each session start. Pre-installing the package removes that dependency.

### **Details (How)**

**Named capture fix** (`app/models/regular_expression.rb`):
Replace `regexp.named_captures.each_key` + `match[name]` with `match.named_captures` — `MatchData#named_captures` returns a correctly UTF-8-encoded `Hash` directly, making the `rescue IndexError/ArgumentError` block unnecessary.

**Railroad diagram fix** (`app/models/regular_expression/railroad_diagram_builder.rb`):
Change `sanitize_group_name` regex from `/\A[A-Za-z_][A-Za-z0-9_]*\z/` to `/\A[\p{L}_][\p{L}\p{N}_]*\z/u`, mirroring Ruby's actual named-capture identifier rules. XSS safety is handled downstream by `sanitize_svg`.

**Playwright MCP** (`package.json`, `.claude/settings.json`):
Add `"@playwright/mcp": "^0.0.76"` to devDependencies. Change the MCP server command from `npx @playwright/mcp@latest` to `node_modules/.bin/playwright-mcp`. Documented the setup and recovery steps in `docs/development.md`.

### **Verification**

- All 217 RSpec examples pass (unit + system tests across Chromium, Firefox, WebKit)
- Rubocop, erb_lint, Biome, gitleaks, brakeman: all clean
- Manually confirmed in the Rails dev server (`localhost:3000`): `(?<あ>x)\k<あ>` now shows `group: あ` in the railroad diagram with no error message
- Playwright MCP bug reproduction screenshots stored in `docs/onigmo-bugs/` (gitignored — local investigation artifact)

### **Additional Notes**

- `docs/onigmo-bugs/` and `.playwright-mcp/` are added to `.gitignore` — these are local investigation artifacts and not part of the shipped product.
- WASM crash behaviour for CF3 (ReDoS) and CP1 (infinite loop) is a known limitation (`Timeout::timeout` is unavailable in the WASM environment); no code change is made for those cases.