### PR TITLE
chore: build CSS assets before running tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build frontend assets
-        run: yarn build
+        run: yarn build && yarn build:css
 
       - name: Run tests
         run: bin/rspec


### PR DESCRIPTION
### **Overview (What)**

Add `yarn build:css` to the CI asset build step so `application.css` is present before `bin/rspec` runs.

### **Background (Why)**

PR #645 changed `stylesheet_link_tag :app` to `stylesheet_link_tag "application", "custom_styles"`. The old symbol form caused Propshaft to silently emit a 404 link tag for the missing `app.css`; the new explicit string form raises `Propshaft::MissingAssetError` when `application.css` is absent.

CI only ran `yarn build` (esbuild — JS only). `application.css` is produced by `yarn build:css` (Tailwind CLI) and is gitignored, so it was never present in the test environment.

### **Details (How)**

One-line change: `yarn build` → `yarn build && yarn build:css` in `.github/workflows/ci.yml`.

### **Verification**

- All 217 RSpec examples pass locally with CSS built
- pre-push hooks (Firefox / WebKit / Chrome system tests) passed

### **Additional Notes**

Follow-up to #645, which was merged before this CI failure was caught.