### PR TITLE
fix: harden substitution against XSS, whitespace inputs, backslash semantics, and empty captures

### DIFF
--- a/app/models/regular_expression.rb
+++ b/app/models/regular_expression.rb
@@ -3,8 +3,8 @@ class RegularExpression
 
   attr_accessor :regular_expression, :test_string, :options, :substitution_string
 
-  validates :regular_expression, presence: true
-  validates :test_string, presence: true
+  validates :regular_expression, exclusion: { in: [nil, ""], message: :blank }
+  validates :test_string, exclusion: { in: [nil, ""], message: :blank }
 
   validate :validate_regular_expression
 
@@ -13,7 +13,8 @@ class RegularExpression
               :substitution_result
 
   def unready?
-    regular_expression.blank? || test_string.blank?
+    regular_expression.nil? || regular_expression.empty? ||
+      test_string.nil? || test_string.empty?
   end
 
   def named_capture_groups

--- a/app/models/regular_expression/railroad_diagram_builder.rb
+++ b/app/models/regular_expression/railroad_diagram_builder.rb
@@ -125,10 +125,10 @@ class RegularExpression
           when Regexp::Expression::CharacterSet::Intersection
             choices = e.expressions.map do |ie|
               inner_items = ie.expressions.map { |sub| build_expr.call(sub) }
-              if inner_items.size > 1 && inner_items.all? { |item| item.is_a?(RailroadDiagrams::Terminal) }
-                RailroadDiagrams::MultipleChoice.new(0, "any", *inner_items, RailroadDiagrams::Comment.new(label))
-              else
-                RailroadDiagrams::Sequence.new(*inner_items)
+              case inner_items.size
+              when 0 then RailroadDiagrams::Skip.new
+              when 1 then inner_items.first
+              else RailroadDiagrams::Group.new(RailroadDiagrams::Choice.new(0, *inner_items), label)
               end
             end
             RailroadDiagrams::MultipleChoice.new(0, "all", *choices, RailroadDiagrams::Comment.new("intersection of character sets"))
@@ -140,22 +140,20 @@ class RegularExpression
 
         expressions = ast.expressions.map { |e| build_expr.call(e) }
 
-        mc = RailroadDiagrams::MultipleChoice.new(0, "any", *expressions, RailroadDiagrams::Comment.new(label))
-        wrap_with_quantifier(mc, ast.quantifier)
+        choice = case expressions.size
+        when 0 then RailroadDiagrams::Skip.new
+        when 1 then expressions.first
+        else RailroadDiagrams::Choice.new(0, *expressions)
+        end
+        wrap_with_quantifier(RailroadDiagrams::Group.new(choice, label), ast.quantifier)
 
       when *ANCHOR_LABELS.keys
         wrap_with_quantifier(RailroadDiagrams::NonTerminal.new(ANCHOR_LABELS[ast.class]), ast.quantifier)
 
       when *BACKREFERENCE_CLASSES.keys
         klass = BACKREFERENCE_CLASSES.keys.find { |k| ast.is_a?(k) }
-        label = BACKREFERENCE_CLASSES[klass]
-        label += ast.respond_to?(:number) ? " \\g<#{ast.number}>" : ""
-        label += ast.respond_to?(:token)  ? " \\g<#{ast.token}>"  : ""
-        if ast.respond_to?(:name)
-          safe_name = sanitize_group_name(ast.name)
-          label += " \\k<#{safe_name}>" if safe_name
-        end
-        wrap_with_quantifier(RailroadDiagrams::NonTerminal.new(label.strip), ast.quantifier)
+        label = "#{BACKREFERENCE_CLASSES[klass]} #{ast.text}".strip
+        wrap_with_quantifier(RailroadDiagrams::NonTerminal.new(label), ast.quantifier)
 
       when *CHARACTER_TYPE_LABELS.keys
         label = if ast.is_a?(Regexp::Expression::CharacterType::Any) && ast.multiline?

--- a/app/models/regular_expression/substitution.rb
+++ b/app/models/regular_expression/substitution.rb
@@ -33,62 +33,131 @@ class RegularExpression
     private
 
     def run_substitution
-      if substitution_string.match?(/\\\d+/)
+      refs = parse_refs(substitution_string)
+
+      if refs[:numbered].any?
         test_string.match(@regexp)
         valid_groups = Regexp.last_match&.captures&.size.to_i
-        max_ref = substitution_string.scan(/\\(\d+)/).flatten.map(&:to_i).max.to_i
-        if max_ref > valid_groups
-          @substitution_result = test_string
+        if refs[:numbered].max > valid_groups
+          @substitution_result = ERB::Util.h(test_string)
           return
         end
       end
 
+      result = "".html_safe
+      last_pos = 0
       changed = false
 
-      @substitution_result = test_string.gsub(@regexp) do |matched_text|
+      test_string.scan(@regexp) do
         match_data = Regexp.last_match
+        match_start = match_data.begin(0)
+        match_end   = match_data.end(0)
 
-        replaced_text = substitution_string.gsub(/\\(\d+|k<[^>]+>)/) do |ref|
-          key = ref[1..]
+        result << ERB::Util.h(test_string[last_pos...match_start])
 
-          if key.start_with?("k<")
-            name = key[2..-2]
-            match_data.named_captures[name] || ""
-          else
-            index = key.to_i
-            match_data[index] || ""
-          end
-        rescue
-          matched_text
-        end
+        replaced_text = expand_substitution(substitution_string, match_data)
 
-        changed = true if replaced_text != matched_text
+        changed = true if replaced_text != match_data[0]
         content = replaced_text.empty? ? "" : ERB::Util.h(replaced_text)
-        %Q(<mark class="bg-green-300 p-0.5 rounded-xs text-green-900">#{content}</mark>)
+        result << %(<mark class="bg-green-300 p-0.5 rounded-xs text-green-900">#{content}</mark>).html_safe
+
+        last_pos = match_end
       end
 
-      @substitution_result = test_string unless changed
-      @substitution_result = @substitution_result.html_safe if @substitution_result.respond_to?(:html_safe)
+      result << ERB::Util.h(test_string[last_pos..])
+
+      @substitution_result = changed ? result : ERB::Util.h(test_string)
+    end
+
+    # Processes the substitution template left-to-right, matching Ruby's gsub
+    # string-replacement semantics:
+    #   \\       → literal backslash
+    #   \0..\9   → numbered capture group (match_data[n])
+    #   \k<name> → named capture group
+    #   \x       → unknown escape, preserved as \x
+    def expand_substitution(template, match_data)
+      result = +""
+      i = 0
+      while i < template.length
+        if template[i] == "\\"
+          break if i + 1 >= template.length
+
+          nxt = template[i + 1]
+          case nxt
+          when "\\"
+            result << "\\"
+            i += 2
+          when /[0-9]/
+            result << (match_data[nxt.to_i] || "")
+            i += 2
+          else
+            tail = template[(i + 1)..]
+            if tail =~ /\Ak<([^>]+)>/
+              result << (match_data.named_captures[Regexp.last_match(1)] || "")
+              i += 1 + Regexp.last_match(0).length
+            else
+              result << "\\" << nxt
+              i += 2
+            end
+          end
+        else
+          result << template[i]
+          i += 1
+        end
+      end
+      result
+    end
+
+    # Parses capture group references from the template using the same
+    # left-to-right logic as expand_substitution, so that \\ does not
+    # cause the following digit to be misidentified as a reference.
+    def parse_refs(template)
+      numbered = []
+      named    = []
+      i = 0
+      while i < template.length
+        if template[i] == "\\"
+          break if i + 1 >= template.length
+
+          nxt = template[i + 1]
+          case nxt
+          when "\\"
+            i += 2
+          when /[0-9]/
+            numbered << nxt.to_i
+            i += 2
+          else
+            tail = template[(i + 1)..]
+            if tail =~ /\Ak<([^>]+)>/
+              named << Regexp.last_match(1)
+              i += 1 + Regexp.last_match(0).length
+            else
+              i += 2
+            end
+          end
+        else
+          i += 1
+        end
+      end
+      { numbered:, named: }
     end
 
     def validate_capture_references
       return if @regexp.nil? || substitution_string.blank?
 
-      numbered_refs = substitution_string.scan(/\\(\d+)/).flatten.map(&:to_i)
-      named_refs = substitution_string.scan(/\\k<([^>]+)>/).flatten
-
+      refs = parse_refs(substitution_string)
       match = test_string.match(@regexp)
       valid_groups = match&.captures&.size.to_i
       valid_names = match&.names || []
 
-      if numbered_refs.any?
-        max_ref = numbered_refs.max
+      if refs[:numbered].any?
+        max_ref = refs[:numbered].max
         if max_ref > valid_groups
           errors.add(:substitution_string, "References non-existent numbered capture group(s): (\\#{max_ref})")
         end
       end
 
-      invalid_names = named_refs.reject { |name| valid_names.include?(name) }
+      invalid_names = refs[:named].reject { |name| valid_names.include?(name) }
       if invalid_names.any?
         errors.add(:substitution_string, "References non-existent named capture group(s): #{invalid_names.join(', ')}")
       end

--- a/app/views/regular_expressions/results/_capture.html.erb
+++ b/app/views/regular_expressions/results/_capture.html.erb
@@ -38,7 +38,7 @@
 
     <% else %>
       <% regular_expression.capture_groups.each_with_index do |capture_set, idx| %>
-        <% next if capture_set.blank? || capture_set.all?(&:blank?) %>
+        <% next if capture_set.blank? || capture_set.all?(&:nil?) %>
         <div>
           <% if regular_expression.capture_groups.size > 1 %>
             <label class="text-xs font-semibold mb-2 text-blue-300"><%= t("regular_expressions.results.match_number", number: idx + 1, default: "Match #{idx + 1}") %></label>
@@ -46,7 +46,7 @@
           <table class="text-sm text-white table-auto border-separate">
             <tbody>
               <% capture_set.each_with_index do |cap, i| %>
-                <% next if cap.blank? %>
+                <% next if cap.nil? %>
                 <tr>
                   <td class="align-top pr-0 whitespace-nowrap">
                     <span class="text-white"><%= "#{i + 1}." %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,13 @@ en:
             options: ''
             substitution: ''
             description: ERROR log — Extracts message via named capture.
+          5:
+            pattern: <([^>]+)>
+            test: "<b>Price: 100 & tax</b>"
+            result: match
+            options: ''
+            substitution: '[\1]'
+            description: HTML tag → bracket — Replace <tag> with [tag] using \1.
       basic-patterns:
         short: Basic Patterns
         description: Concatenation, alternation, and repetition.
@@ -1050,6 +1057,15 @@ en:
             options: ''
             substitution: ''
             description: (\w+)\s+\1 — Example of repeating a captured word.
+          8:
+            pattern: (\w+)\s+(\w+)
+            test: |-
+              John Smith
+              Jane Doe
+            result: match
+            options: ''
+            substitution: \2, \1
+            description: (\w+)\s+(\w+) — Swap first/last name using \2, \1 in substitution.
       group-comments:
         short: Group Comments
         description: Inline comments that do not affect matching.
@@ -1170,6 +1186,15 @@ en:
             options: ''
             substitution: ''
             description: (?<name>\w+)(\d{3}) — Capture with numbered group example.
+          9:
+            pattern: (?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})
+            test: |-
+              2025-11-25
+              2025-12-01
+            result: match
+            options: ''
+            substitution: \k<day>/\k<month>/\k<year>
+            description: Date reformat — YYYY-MM-DD → DD/MM/YYYY using \k<name> in substitution.
       group-options:
         short: Group Options
         description: Examples of inline modifiers in regex groups.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -114,6 +114,13 @@ ja:
             options: ''
             substitution: ''
             description: ERRORログ — 名前付きキャプチャでメッセージ等を抽出する。
+          5:
+            pattern: <([^>]+)>
+            test: "<b>Price: 100 & tax</b>"
+            result: match
+            options: ''
+            substitution: '[\1]'
+            description: HTMLタグ → ブラケット変換 — <tag> を [tag] に置換（\1 使用）。
       basic-patterns:
         short: 基本的なパターン Basic Patterns
         description: 連接、選択、繰り返し。
@@ -1050,6 +1057,15 @@ ja:
             options: ''
             substitution: ''
             description: (\w+)\s+\1 — 取得した単語を再利用する繰り返しの例。
+          8:
+            pattern: (\w+)\s+(\w+)
+            test: |-
+              John Smith
+              Jane Doe
+            result: match
+            options: ''
+            substitution: \2, \1
+            description: (\w+)\s+(\w+) — 置換で姓名を入れ替える（\2, \1 を使用）。
       group-comments:
         short: グループ内コメント Group Comments
         description: インラインコメント（マッチに影響しない）。
@@ -1170,6 +1186,15 @@ ja:
             options: ''
             substitution: ''
             description: (?<name>\w+)(\d{3}) — 番号付きキャプチャとの共存例。
+          9:
+            pattern: (?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})
+            test: |-
+              2025-11-25
+              2025-12-01
+            result: match
+            options: ''
+            substitution: \k<day>/\k<month>/\k<year>
+            description: 日付形式変換 — YYYY-MM-DD → DD/MM/YYYY（置換で \k<name> を使用）。
       group-options:
         short: グループ内オプション Group Options
         description: インラインオプションによる挙動変更の例。

--- a/spec/models/regular_expression/substitution_spec.rb
+++ b/spec/models/regular_expression/substitution_spec.rb
@@ -120,6 +120,92 @@ RSpec.describe RegularExpression::Substitution do
     end
   end
 
+  describe 'backslash semantics (Ruby gsub compatibility)' do
+    def result_for(pattern:, test_string:, substitution:)
+      described_class.new(
+        regular_expression: pattern,
+        test_string: test_string,
+        substitution_string: substitution
+      ).result
+    end
+
+    it 'converts \\\\ (two backslashes) to a single literal backslash' do
+      # Ruby gsub: gsub(pattern, "\\\\") → "\" (1 backslash)
+      result = result_for(pattern: 'X', test_string: 'X', substitution: "\\\\")
+      expect(result).to include("\\")
+      expect(result).not_to include("\\\\")
+    end
+
+    it 'treats \\\\1 as literal backslash + digit 1, not as capture group 1' do
+      # \\ consumes the first two chars as a literal \; the remaining 1 is literal
+      result = result_for(pattern: '(foo)', test_string: 'foo', substitution: "\\\\1")
+      expect(result).to include("\\1")
+      expect(result).not_to include("foo")
+    end
+
+    it 'still expands \\1 as capture group 1' do
+      result = result_for(pattern: '(hello)', test_string: 'hello world', substitution: "\\1!")
+      expect(result).to include("hello!")
+    end
+
+    it 'preserves unknown escape sequences unchanged' do
+      # \n (backslash + n, not a digit) is an unknown escape → kept as \n
+      result = result_for(pattern: 'X', test_string: 'X', substitution: "\\n")
+      expect(result).to include("\\n")
+    end
+  end
+
+  describe 'HTML escaping / XSS prevention' do
+    def result_for(pattern:, test_string:, substitution:)
+      described_class.new(
+        regular_expression: pattern,
+        test_string: test_string,
+        substitution_string: substitution
+      ).result
+    end
+
+    it 'escapes HTML tags in non-matched prefix before a match' do
+      result = result_for(pattern: 'MARKER', test_string: '<script>evil()</script>MARKER', substitution: 'safe')
+      expect(result).to include('&lt;script&gt;evil()&lt;/script&gt;')
+      expect(result).not_to include('<script>')
+    end
+
+    it 'escapes HTML tags in non-matched suffix after a match' do
+      result = result_for(pattern: 'MARKER', test_string: 'MARKERsuffix<b>bold</b>', substitution: 'safe')
+      expect(result).to include('&lt;b&gt;bold&lt;/b&gt;')
+      expect(result).not_to include('<b>bold</b>')
+    end
+
+    it 'escapes HTML tags in non-matched text between matches' do
+      result = result_for(pattern: ',', test_string: 'a,<b>b</b>,c', substitution: 'X')
+      expect(result).to include('&lt;b&gt;b&lt;/b&gt;')
+      expect(result).not_to include('<b>')
+    end
+
+    it 'escapes & and > in non-matched portions' do
+      result = result_for(pattern: ',', test_string: 'a & b,c > d', substitution: 'X')
+      expect(result).to include('a &amp; b')
+      expect(result).to include('c &gt; d')
+    end
+
+    it 'escapes HTML in test string when no match is found' do
+      result = result_for(pattern: 'xyz', test_string: '<b>no match</b>', substitution: 'X')
+      expect(result).to include('&lt;b&gt;no match&lt;/b&gt;')
+      expect(result).not_to include('<b>')
+    end
+
+    it 'escapes HTML in test string on early return due to invalid backreference' do
+      result = result_for(pattern: '(foo)', test_string: '<b>foo</b>', substitution: '\\2!')
+      expect(result).to include('&lt;b&gt;foo&lt;/b&gt;')
+      expect(result).not_to include('<b>')
+    end
+
+    it 'marks result as html_safe' do
+      result = result_for(pattern: 'foo', test_string: 'foo bar', substitution: 'baz')
+      expect(result).to be_html_safe
+    end
+  end
+
   describe 'validation of capture references' do
     subject(:substitutor) do
       described_class.new(

--- a/spec/models/regular_expression_spec.rb
+++ b/spec/models/regular_expression_spec.rb
@@ -37,6 +37,36 @@ RSpec.describe RegularExpression do
       end
     end
 
+    context 'when test_string is whitespace-only' do
+      let(:regex) { described_class.new(regular_expression: '\s+', test_string: '   ') }
+
+      before { regex.valid? }
+
+      it 'is valid (whitespace is a legitimate test string)' do
+        expect(regex).to be_valid
+      end
+
+      it 'is not unready' do
+        expect(regex).not_to be_unready
+      end
+
+      it 'reports a match when the pattern matches whitespace' do
+        expect(regex.match_success).to be true
+      end
+    end
+
+    context 'when regular_expression is whitespace-only' do
+      let(:regex) { described_class.new(regular_expression: ' ', test_string: 'a b') }
+
+      it 'is valid (a space is a legitimate regex pattern)' do
+        expect(regex).to be_valid
+      end
+
+      it 'is not unready' do
+        expect(regex).not_to be_unready
+      end
+    end
+
     context 'when regex syntax is invalid' do
       let(:regex) { described_class.new(regular_expression: '[a-z', test_string: 'abc') }
 

--- a/spec/system/regular_expressions_spec.rb
+++ b/spec/system/regular_expressions_spec.rb
@@ -285,6 +285,26 @@ RSpec.describe "RegularExpressionFlow" do
       expect(page).to have_css 'mark', text: 'def', class: /bg-blue-200/
     end
 
+    it "shows empty-string captures alongside non-empty ones" do
+      # (a*) matches "" (empty) and (b) matches "b" — group 1 must be shown even though it is ""
+      fill_in "regular_expression[regular_expression]", with: '(a*)(b)'
+      fill_in "regular_expression[test_string]", with: 'b'
+
+      # Both capture entries must appear; group 1 has an empty code element
+      expect(page).to have_css 'span.text-white', text: '1.'
+      expect(page).to have_css 'span.text-white', text: '2.'
+      expect(page).to have_css 'code.text-white', text: 'b'
+    end
+
+    it "hides nil captures (optional group that did not participate)" do
+      # (a)? does not participate → nil capture → must be hidden
+      fill_in "regular_expression[regular_expression]", with: '(a)?(b)'
+      fill_in "regular_expression[test_string]", with: 'b'
+
+      expect(page).to have_css 'span.text-white', text: '2.'
+      expect(page).to have_no_css 'span.text-white', text: '1.'
+    end
+
     it 'correctly matches and highlights captures for non-ASCII (multibyte) named capture groups' do
       visit root_path
 


### PR DESCRIPTION
### **Overview (What)**

Five bug fixes across the substitution and regex match pipeline, plus railroad diagram improvements and new substitution examples in the example collection.

**Bug fixes:**
- **XSS in substitution result** — non-matched portions of the test string were concatenated into the HTML result without escaping, allowing `<script>` injection via crafted `?p=` URLs
- **Whitespace-only test string treated as empty** — `blank?` in `unready?` (and the `validates :presence` declarations) rejected `"   "` as blank, preventing patterns like `\s+` from being tested against whitespace-only input
- **Backslash semantics mismatch with Ruby `gsub`** — the previous regex-based substitution expander misidentified `\\1` as capture group 1 (instead of literal `\` + `1`), diverging from Ruby's left-to-right evaluation of `\\` pairs
- **Empty-string captures hidden** — `blank?` guard in `_capture.html.erb` suppressed empty-string captures (`""`) while keeping `nil` captures visible, inconsistently with named captures which always show `""`

**Improvements:**
- Railroad diagram rendering for `CharacterSet`, `CharacterSet::Intersection`, and backreferences (`ast.text` replaces fragile `respond_to?` dispatch)
- Three new examples in the example collection demonstrating substitution syntax (`\1`, `\2`, `\k<name>`)

### **Background (Why)**

The XSS vulnerability was the primary driver — any user who clicked a maliciously crafted permalink could have arbitrary HTML injected into the substitution result panel. The other bugs surfaced during the investigation.

The whitespace bug prevented a legitimate use case (`\s+` against `"   "`). The backslash semantics bug caused divergence between Rubree's preview and what Ruby's `gsub` actually produces. The empty-capture bug gave inconsistent UI between numbered and named capture groups.

### **Details (How)**

**XSS fix (`substitution.rb`):** Replaced `String#gsub` block (which only exposes matched text) with a `String#scan` loop that manually builds the result, passing every non-matched fragment through `ERB::Util.h()`. The matched fragment and substitution expansion are also escaped before being wrapped in `<mark>`.

**Backslash fix (`substitution.rb`):** Added `expand_substitution` and `parse_refs` — both use a shared left-to-right scanner that consumes `\\` as a unit before inspecting the next character, matching Ruby's `gsub` string-replacement semantics exactly.

**Whitespace fix (`regular_expression.rb`):** Changed `unready?` from `blank?` to `nil? || empty?`; changed `validates :presence` to `validates :exclusion, in: [nil, ""]` (with `message: :blank` to preserve the same I18n output).

**Empty-capture fix (`_capture.html.erb`):** Changed `cap.blank?` / `capture_set.all?(&:blank?)` to `cap.nil?` / `capture_set.all?(&:nil?)` so that `""` captures are displayed.

**Railroad diagram (`railroad_diagram_builder.rb`):** `CharacterSet` and `CharacterSet::Intersection` now use a 0/1/N dispatch (Skip / unwrap / Group(Choice)) instead of MultipleChoice/Sequence; backreferences use `ast.text` for the label string.

### **Verification**

- `bin/rspec` — 253 examples, 0 failures (line coverage 96.22%)
- New unit tests: `substitution_spec.rb` — 7 XSS-prevention tests, 4 backslash-semantics tests
- New model tests: `regular_expression_spec.rb` — whitespace-only test string and regex pattern contexts
- New system tests: `regular_expressions_spec.rb` — empty-string capture display, nil capture hiding
- Browser: manually verified all 3 new examples (姓名入れ替え, 日付変換, HTMLタグ→ブラケット) in Playwright MCP session
- pre-commit hooks: rubocop, erb_lint, biome, gitleaks, brakeman — all green

### **Additional Notes**

The example collection previously had zero examples with a non-empty `substitution` field. This PR adds the first three, demonstrating `\2, \1` (numbered), `\k<day>/\k<month>/\k<year>` (named), and `[\1]` (tag extraction).