### PR TITLE
fix: bump npm playwright to 1.62.1 to match playwright-ruby-client gem

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@biomejs/biome": "2.5.6",
     "@playwright/mcp": "^0.0.78",
     "esbuild": "^0.28.1",
-    "playwright": "1.59.1"
+    "playwright": "1.62.1"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,24 +718,15 @@ picomatch@>=4.0.4, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
-playwright-core@1.59.1:
-  version "1.59.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
-  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
-
 playwright-core@1.62.0-alpha-1783623505000:
   version "1.62.0-alpha-1783623505000"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.62.0-alpha-1783623505000.tgz#3984745e615ad065b24a89edeeec1a653addc807"
   integrity sha512-CPJZdsA/KGT2QQlekiV6Wt+QlQrZHVSZ6oiNtOI/bYYOIVLM8jfKGWTM4zQiyd4UN+40Cq4cA6lxmZHZbtPvJQ==
 
-playwright@1.59.1:
-  version "1.59.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
-  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
-  dependencies:
-    playwright-core "1.59.1"
-  optionalDependencies:
-    fsevents "2.3.2"
+playwright-core@1.62.1:
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.62.1.tgz#120f67a19181bfd183c60fa903c0d99330b56785"
+  integrity sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==
 
 playwright@1.62.0-alpha-1783623505000:
   version "1.62.0-alpha-1783623505000"
@@ -743,6 +734,15 @@ playwright@1.62.0-alpha-1783623505000:
   integrity sha512-6KV9h4PP3hqu4NaGdxxcijWfYh9LJcFI/R2sP4TTC4I5cFo3oRawN0ETlW5MkE3cQEgKhhoj0KUNz4sfpCT0Tg==
   dependencies:
     playwright-core "1.62.0-alpha-1783623505000"
+  optionalDependencies:
+    fsevents "2.3.2"
+
+playwright@1.62.1:
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.62.1.tgz#8447b6755e8aec85a3cb7207c823e3ed2fc66700"
+  integrity sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==
+  dependencies:
+    playwright-core "1.62.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
### **Overview (What)**
Bump the npm `playwright` devDependency from `1.59.1` to `1.62.1` to match the `playwright-ruby-client` gem.

### **Background (Why)**
CI (`Run Tests`) started failing on all system specs with:

```
Playwright::Error:
  timeout: expected float, got undefined
```

This is a version-drift issue between the Ruby gem and the npm package, the same failure pattern seen before
(#490, #520, #531, and the "strict version match" fix in commit `b67296a`).

`playwright-ruby-client` was bumped to `1.62.0` by Dependabot (#721), but `.github/dependabot.yml` intentionally
`ignore`s the npm `playwright` package to avoid it drifting ahead of the Ruby gem. This time the gem moved first:
gem `1.62.0`'s `COMPATIBLE_PLAYWRIGHT_VERSION` is `1.62.1`, while npm `playwright` was still pinned at `1.59.1` —
a big enough protocol gap to break `BrowserType#launch`.

Note: PR #721 merged via Dependabot auto-merge despite `Run Tests` failing, so `main` is currently broken for
system specs until this lands.

### **Details (How)**
- `package.json`: `playwright` `1.59.1` → `1.62.1` (exact pin, no caret, consistent with existing style)
- `yarn.lock`: regenerated via `yarn install` (`playwright` / `playwright-core` → `1.62.1`)
- No CI workflow changes needed — the Playwright browser cache key in `ci.yml` is derived from
  `package.json`'s `devDependencies.playwright`, so it automatically busts and reinstalls the matching browser.

### **Verification**
- `npx playwright install && npx playwright install-deps` (all browsers, to match local pre-push hooks)
- `bin/rspec spec/system` — 43 examples, 0 failures (previously failed with the Playwright launch error)
- `bin/rubocop`, `bin/erb_lint --lint-all`, `bin/yarn biome check` — all clean
- Local `pre-push` hook (Firefox / WebKit / Selenium-Chrome system spec runs) — all green

### **Additional Notes**
A follow-up PR will add a Dependabot `cooldown` setting to reduce the chance of this kind of drift (and as a
general supply-chain safety measure) recurring.