### PR TITLE
chore: add Dependabot cooldown to delay dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
     versioning-strategy: lockfile-only
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
     allow:
       - dependency-type: direct
       - dependency-type: indirect
@@ -45,6 +50,11 @@ updates:
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
     versioning-strategy: auto
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
     labels:
       - dependencies
       - javascript
@@ -75,6 +85,11 @@ updates:
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
     versioning-strategy: auto
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
     labels:
       - dependencies
       - javascript
@@ -93,6 +108,11 @@ updates:
       interval: daily
       time: '12:00'
       timezone: Asia/Tokyo
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
     labels:
       - dependencies
       - gh-action


### PR DESCRIPTION
### **Overview (What)**
Add a `cooldown` setting to every `updates` block in `.github/dependabot.yml` (bundler `/`, npm `/`, npm `/pwa`,
github-actions `/`): `default-days: 14`, `semver-major-days: 30`, `semver-minor-days: 14`, `semver-patch-days: 7`.

### **Background (Why)**
Follow-up to #723. The root cause there was Dependabot picking up `playwright-ruby-client` 1.62.0 the moment it
was released and auto-merging it before compatibility with the (intentionally frozen) npm `playwright` package
could be verified — main ended up broken.

A cooldown period gives newly-released versions time to be vetted by the wider community before this repo pulls
them in, which also reduces exposure to supply-chain issues (a malicious or broken release caught/yanked within
the cooldown window never reaches a PR here). Security-alert PRs are unaffected by cooldown per Dependabot's
behavior — vulnerability fixes still land immediately.

### **Details (How)**
Added the same `cooldown` block to all four `updates` entries so the policy is consistent across ecosystems.
Existing `ignore`/`groups`/`allow` settings are untouched.

### **Verification**
- YAML parses cleanly: `ruby -ryaml -e "YAML.load_file('.github/dependabot.yml')"`
- No functional test coverage applies to Dependabot config; behavior will be observable on the next scheduled
  Dependabot run (updates should no longer appear until 7/14/30 days after release, depending on semver level).

### **Additional Notes**
Related: #723 (the CI fix this is a follow-up to).