### PR TITLE
chore: fix devcontainer setup on arm64 hosts

### DIFF
--- a/.claude/skills/testing-guidelines/SKILL.md
+++ b/.claude/skills/testing-guidelines/SKILL.md
@@ -154,3 +154,12 @@ end
 Outside the Dev Container (local macOS install), this block is skipped and the default driver
 configuration applies. If Chrome behaves unexpectedly in CI but not locally, check whether the
 Selenium driver is picking up the right options for its environment.
+
+**arm64 hosts (e.g. Apple Silicon Macs) can't run this check at all.** Google publishes no
+arm64 build of Chrome, and Ubuntu's `chromium` apt package is just a stub that requires snap
+(unreliable inside containers) — there's no working substitute, so `.devcontainer/setup.sh`
+skips the install entirely on arm64. The pre-push "Selenium/Chrome" check (and any manual
+`DRIVER=selenium_chrome_headless` run) simply isn't available on those hosts. Rely on the
+Playwright Firefox/WebKit checks (also part of `pre-push`) and CI's Playwright/Chromium
+coverage instead — between those, Rubree's supported browsers (Chrome and Edge are both
+Chromium-based) are still reasonably covered.

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -95,7 +95,16 @@ if ! command -v wasi-vfs &>/dev/null; then
 fi
 
 # --- Google Chrome (for Selenium/Chrome system tests) ---
-if ! command -v google-chrome &>/dev/null; then
+# Google publishes no arm64 build of Chrome, and Ubuntu's own `chromium` apt package is
+# just a stub that requires snap (unreliable in containers), so there's no good arm64
+# substitute here. Skip on arm64 hosts (e.g. Apple Silicon Macs) — the "Selenium/Chrome"
+# pre-push check simply isn't available there; Playwright's Firefox/WebKit checks and
+# CI's Chromium coverage still apply. See testing-guidelines skill § Selenium/Chrome
+# inside the Dev Container.
+if [ "$(uname -m)" = "aarch64" ]; then
+  echo "arm64 host detected: skipping Google Chrome install (no arm64 build available)."
+  echo "The pre-push 'Selenium/Chrome' check will not work on this host."
+elif ! command -v google-chrome &>/dev/null; then
   curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o /tmp/google-chrome.deb
   sudo apt-get install -y /tmp/google-chrome.deb
   rm /tmp/google-chrome.deb

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 WORKSPACE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Avoid apt-get blocking on the interactive "restart services?" prompt that
+# needrestart triggers on Ubuntu 24.04+ in a non-interactive shell.
+export NEEDRESTART_MODE=a
+
 # --- System dependencies ---
 sudo apt-get update -qq
 sudo apt-get install -y \
@@ -59,10 +63,19 @@ sudo ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/yarn" /usr/local/bin/yarn
 # chromium: used by Playwright MCP server
 # chromium-headless-shell: used by capybara-playwright-driver in RSpec system tests
 # firefox, webkit: used by pre-push system tests (lefthook)
-if ! npx -y playwright --version &>/dev/null; then
-  npx -y playwright install chromium chromium-headless-shell firefox webkit --with-deps
-else
-  npx playwright install chromium chromium-headless-shell firefox webkit --with-deps
+#
+# Installed one browser at a time (binary + deps as separate commands, mirroring
+# ci.yml) instead of one combined `--with-deps` call, so a slow/stuck browser is
+# identifiable in the log instead of one opaque hang. Each step is capped with
+# `timeout` so a genuine hang fails loudly instead of blocking container creation
+# forever (seen on some arm64 hosts).
+#
+# Skip this step entirely with: touch .skip-playwright-install
+if [ ! -f "$WORKSPACE_ROOT/.skip-playwright-install" ]; then
+  for browser in chromium chromium-headless-shell firefox webkit; do
+    timeout 900 npx -y playwright install "$browser"
+    timeout 900 npx -y playwright install-deps "$browser"
+  done
 fi
 
 # --- Rust + wasi-vfs ---

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 # Marker file to opt in to installing Claude Code in the Dev Container.
 /.install-claude-code
 
+# Marker file to opt out of Playwright browser install in the Dev Container
+# (e.g. if it hangs/times out on your architecture).
+/.skip-playwright-install
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,16 @@ Setup, linting, and test commands for working on Rubree locally.
    curl -fsSL https://claude.ai/install.sh | bash
    ```
 
+3. (Optional) Skip Playwright browser installation if it hangs or times out on your machine
+   (seen on some arm64 hosts):
+
+   ```sh
+   touch .skip-playwright-install   # gitignored, scoped to this clone
+   ```
+
+   You'll need to install the browsers manually later for system tests / Playwright MCP:
+   `npx playwright install <browser> && npx playwright install-deps <browser>`.
+
 ### Manual setup (without Dev Container)
 
 ```sh


### PR DESCRIPTION
### **Overview (What)**
Fixes `.devcontainer/setup.sh` so it doesn't hang or fail outright on arm64 devcontainer hosts (e.g. Apple Silicon Macs). Works fine on Windows/amd64 already; this is arm64-only.

### **Background (Why)**
Two separate arm64 issues surfaced while investigating a reported hang during `postCreateCommand`:

1. **Playwright browser install hangs.** The combined `playwright install chromium chromium-headless-shell firefox webkit --with-deps` call gives no signal which browser is stuck, and Ubuntu 24.04's `needrestart` can pop an interactive "restart services?" prompt during `apt-get install` that blocks forever in a non-interactive shell.
2. **Google Chrome install fails outright on arm64.** Google publishes no arm64 build of Chrome (the script downloads `google-chrome-stable_current_amd64.deb`), and Ubuntu's own `chromium` apt package turned out to be a stub requiring snap (unreliable in containers) — verified this in a live arm64 sandbox: `chromium-browser` from apt just prints "requires the chromium snap to be installed" and exits.

### **Details (How)**
- `export NEEDRESTART_MODE=a` near the top of the script, covering every `apt-get install` call in the script (build deps, gh CLI, Playwright's `install-deps`), not just Playwright.
- Install each Playwright browser individually (`npx playwright install <browser>` then `install-deps <browser>`, separately) instead of one combined `--with-deps` call, mirroring the pattern `ci.yml` already uses for chromium. Each step is wrapped in `timeout 900` so a genuine hang fails loudly instead of blocking container creation forever.
- Added a `.skip-playwright-install` opt-out marker file (gitignored), mirroring the existing `.install-claude-code` convention, documented in `docs/development.md`.
- On arm64, skip the Google Chrome install entirely with a clear message rather than failing the whole script — the pre-push "Selenium/Chrome" check just isn't available there. Documented in the `testing-guidelines` skill.

### **Verification**
- `bash -n .devcontainer/setup.sh` — syntax check.
- Live-tested in an arm64 sandbox: `NEEDRESTART_MODE=a` + per-browser `playwright install chromium` + `install-deps chromium` completed in ~1 minute with no hang (previously reported as hanging indefinitely). Full `bin/rspec` suite (270 examples) then passed using the installed Chromium.
- Confirmed `apt install chromium` on Ubuntu 24.04 arm64 does NOT provide a working browser (snap stub) — this ruled out an earlier draft of this fix that tried to substitute Chromium for Selenium/Chrome.
- Could not reproduce the *original* hang (pre-fix) in this environment to do a true before/after comparison — reporter should confirm on their actual arm64 machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)