### PR TITLE
chore: disable brakeman --ensure-latest, bump to 8.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,10 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
+# Rails' default bin/brakeman stub adds --ensure-latest here, which fails CI whenever a
+# newer Brakeman release exists on RubyGems — even during the window before Dependabot's
+# cooldown (.github/dependabot.yml) has had a chance to open the bump PR. Disabled so CI
+# red only reflects real Brakeman findings, not version staleness.
+# ARGV.unshift("--ensure-latest")
 
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
### **Overview (What)**
Disables the `--ensure-latest` flag in `bin/brakeman` and bumps the locked brakeman version to 8.0.6 to clear a current CI failure.

### **Background (Why)**
CI's SAST step (`bin/brakeman`) was failing with a version-staleness error, not a real security finding. The root cause: `--ensure-latest` is Rails' own default `bin/brakeman` stub (added since Rails 7.2 — confirmed against `railties/lib/rails/generators/rails/app/templates/bin/brakeman.tt`), and it hard-fails the moment a newer Brakeman is published on RubyGems.

Dependabot does track brakeman (bundler ecosystem, ungrouped → its own PR), but `.github/dependabot.yml`'s `cooldown` (`semver-patch-days: 7`, etc.) intentionally delays even patch bumps by up to a week for stability. That creates a window — between a Brakeman release and Dependabot's cooldown-gated PR — where CI is red for a reason that has nothing to do with this app's code and looks confusing to debug.

Considered scoping a `cooldown.exclude: ["brakeman"]` entry instead (keeps bleeding-edge freshness, GitHub's docs confirm `exclude` bypasses cooldown per-dependency), but that trades one confusing failure mode for an ongoing per-package exception to maintain — not worth it for what this flag buys.

### **Details (How)**
- `bin/brakeman`: commented out `ARGV.unshift("--ensure-latest")` rather than deleting it, since it's a Rails standard and this is an intentional local deviation — left with a comment explaining why, so it doesn't silently disappear from view.
- `Gemfile.lock`: bumped `brakeman` 8.0.5 → 8.0.6 to clear the currently-failing CI run.

### **Verification**
- `bin/brakeman --no-pager --skip-files app/assets/builds/,build/,node_modules/,pwa/,rubies/` — runs clean, 0 security warnings, Brakeman 8.0.6.
- Full `bin/rspec` suite (270 examples) passes.
- `bin/rubocop`, `bin/erb_lint --lint-all`, `bin/yarn biome check`, gitleaks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)